### PR TITLE
fix: update readme docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 DeepEquilibriumNetworks.jl is a framework built on top of
 [DifferentialEquations.jl](https://docs.sciml.ai/DiffEqDocs/stable/) and
-[Lux.jl](https://docs.sciml.ai/Lux/stable/) enabling the efficient training and inference for
+[Lux.jl](https://lux.csail.mit.edu/) enabling the efficient training and inference for
 Deep Equilibrium Networks (Infinitely Deep Neural Networks).
 
 ## Installation


### PR DESCRIPTION
As it stands, clicking on the link for lux (https://docs.sciml.ai/Lux/stable/)  returns a 403 forbidden. This commit tries to update the hyperlink to where the docs actually live (https://lux.csail.mit.edu/)