### PR TITLE
Remove recompile_invalidations

### DIFF
--- a/src/DeepEquilibriumNetworks.jl
+++ b/src/DeepEquilibriumNetworks.jl
@@ -1,25 +1,21 @@
 module DeepEquilibriumNetworks
 
-import PrecompileTools: @recompile_invalidations
-
-@recompile_invalidations begin
-    using ADTypes: AutoFiniteDiff, AutoForwardDiff, AutoZygote
-    using ChainRulesCore: ChainRulesCore
-    using CommonSolve: solve
-    using ConcreteStructs: @concrete
-    using ConstructionBase: ConstructionBase
-    using DiffEqBase: DiffEqBase, AbsNormTerminationMode
-    using FastClosures: @closure
-    using Lux: Lux, BranchLayer, Chain, NoOpLayer, Parallel, RepeatedLayer,
-               StatefulLuxLayer, WrappedFunction
-    using LuxCore: LuxCore, AbstractExplicitLayer, AbstractExplicitContainerLayer
-    using NNlib: ⊠
-    using Random: Random, AbstractRNG, randn!
-    using SciMLBase: SciMLBase, AbstractNonlinearAlgorithm, AbstractODEAlgorithm,
-                     NonlinearSolution, ODESolution, ODEFunction, ODEProblem,
-                     SteadyStateProblem, _unwrap_val
-    using SteadyStateDiffEq: DynamicSS, SSRootfind
-end
+using ADTypes: AutoFiniteDiff, AutoForwardDiff, AutoZygote
+using ChainRulesCore: ChainRulesCore
+using CommonSolve: solve
+using ConcreteStructs: @concrete
+using ConstructionBase: ConstructionBase
+using DiffEqBase: DiffEqBase, AbsNormTerminationMode
+using FastClosures: @closure
+using Lux: Lux, BranchLayer, Chain, NoOpLayer, Parallel, RepeatedLayer,
+           StatefulLuxLayer, WrappedFunction
+using LuxCore: LuxCore, AbstractExplicitLayer, AbstractExplicitContainerLayer
+using NNlib: ⊠
+using Random: Random, AbstractRNG, randn!
+using SciMLBase: SciMLBase, AbstractNonlinearAlgorithm, AbstractODEAlgorithm,
+                 NonlinearSolution, ODESolution, ODEFunction, ODEProblem,
+                 SteadyStateProblem, _unwrap_val
+using SteadyStateDiffEq: DynamicSS, SSRootfind
 
 # Useful Constants
 const CRC = ChainRulesCore


### PR DESCRIPTION
`@recompile_invalidations` should only be used in very specific scenarios, and this is not one of those scenarios. Also, there are big changes being done with https://github.com/SciML/CommonWorldInvalidations.jl. With that, we only need to `@recompile_invalidations` on a few entry points. In particular, Static.jl, Symbolics.jl, and preferably ForwardDiff.jl and StaticArrays.jl would adopt it too. But this means that in order to handle all of this effectively, in SciML we only need to apply it on Static.jl, Symbolics.jl, and SciMLBase.jl and the whole ecosystem should be fine.

In any case, this library doesn't need it. It shouldn't make a tangible difference in compile times, while it increases precompile times by a lot.
