### PR TITLE
Fix(CI): Update branch references to main

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -2,12 +2,12 @@ name: Downgrade
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
 jobs:


### PR DESCRIPTION
This PR updates the CI workflow files to reference the \main\ branch instead of \master\, ensuring that the CI runs on the correct default branch.

Created by RooCode, an AI tool.