### PR TITLE
Migrate CI to centralized SciML/.github reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -10,23 +10,13 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
+
 jobs:
-  test:
+  downgrade:
     if: false  # Disabled: waiting on SciML ecosystem updates. See #193 for details.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,5 +1,4 @@
 name: format-check
-
 on:
   push:
     branches:
@@ -11,12 +10,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic Format Check"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,13 +1,8 @@
 name: Spell Check
-
 on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.1 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  tests:
+    name: "Tests"
     strategy:
       fail-fast: false
       matrix:
@@ -27,29 +27,8 @@ jobs:
         version:
           - 'lts'
           - '1'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-      - uses: actions/cache@v5
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          coverage: true
-        env:
-          GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info
-          fail_ci_if_error: false
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      group: "${{ matrix.group }}"
+    secrets: "inherit"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,19 @@
+name: Documentation
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    tags: '*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
+
+jobs:
+  docs:
+    name: "Documentation"
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Normalizes CI to the SciML centralized reusable workflows (all pinned `@v1`, each caller passes `secrets: "inherit"`).

## Workflows converted
- **Tests.yml** (`name: CI`) → calls `tests.yml@v1`. Preserves the exact matrix `group: [CPU, QA]` × `version: [lts, "1"]`, `fail-fast: false`, the `push`/`pull_request` triggers with `paths-ignore: docs/**`, and the concurrency group. Coverage left at the workflow default (`true`) to match the original (it collected coverage via codecov).
- **Downgrade.yml** → calls `downgrade.yml@v1` with `julia-version: "1.10"` and `skip: "Pkg,TOML"`. **Kept disabled** with `if: false` (and the original explanatory comment referencing #193), exactly as before.
- **FormatCheck.yml** (`name: format-check`) → calls `runic.yml@v1`. Same triggers as before.
- **SpellCheck.yml** (`name: Spell Check`) → calls `spellcheck.yml@v1`.

## Workflows added
- **documentation.yml** → calls `documentation.yml@v1` (repo has `docs/make.jl` and `docs/Project.toml`). This is the standard centralized Documentation build/deploy caller. Note the existing `GPU.yml` already builds docs on self-hosted GPU runners; that workflow is left untouched.

## Workflows left unchanged
- **GPU.yml** — self-hosted CUDA tests + GPU docs build; outside the standard set, preserved as-is.
- **TagBot.yml** — unchanged.

## Dependabot
- Removed the `crate-ci/typos` `ignore` block from the `github-actions` updates (standing policy: keep everything current, no per-dependency ignores).
- Preserved the existing `julia` ecosystem block (directories `/`, `/docs`, `/test`; daily; `all-julia-packages` group). Not narrowed.

## CompatHelper
- No `CompatHelper.yml` was present; nothing removed.

## Runic formatting
- The repo already ran Runic in CI. Ran `Runic.main(["--check", ...])` locally (Runic v1.7.0): clean, exit 0. **No formatting changes were needed or made.**

## Typos
- Ran `typos` locally against the existing `.typos.toml`: clean, exit 0. The centralized check uses a newer typos version (v1.47.0 vs the previous pinned v1.18.1); no new findings observed locally.

## Heads-up
- **Check names change.** Branch-protection required-status-checks will need to be updated to the new job names (e.g. `Tests`, `Documentation`, `Runic Format Check`, `Spell Check with Typos`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)