### PR TITLE
Fix OrdinaryDiffEq 7.0.0 re-export breakage in tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -45,6 +45,7 @@ NNlib = "0.9"
 NonlinearSolve = "4"
 NonlinearSolveBase = "1.5, 2"
 OrdinaryDiffEq = "6.74, 7"
+OrdinaryDiffEqAdamsBashforthMoulton = "1, 2"
 Pkg = "1.10"
 PrecompileTools = "1.2.1"
 Random = "1.10"
@@ -71,6 +72,7 @@ MLDataDevices = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqAdamsBashforthMoulton = "89bda076-bce5-4f1c-845f-551c83cdda9a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SciMLSensitivity = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -78,4 +80,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "Documenter", "ExplicitImports", "ForwardDiff", "Functors", "GPUArraysCore", "InteractiveUtils", "LuxTestUtils", "MLDataDevices", "NLsolve", "NonlinearSolve", "OrdinaryDiffEq", "Pkg", "SafeTestsets", "SciMLSensitivity", "StableRNGs", "Test", "Zygote"]
+test = ["Aqua", "Documenter", "ExplicitImports", "ForwardDiff", "Functors", "GPUArraysCore", "InteractiveUtils", "LuxTestUtils", "MLDataDevices", "NLsolve", "NonlinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqAdamsBashforthMoulton", "Pkg", "SafeTestsets", "SciMLSensitivity", "StableRNGs", "Test", "Zygote"]

--- a/test/layers_tests.jl
+++ b/test/layers_tests.jl
@@ -1,6 +1,8 @@
 include("shared_testsetup.jl")
 
 using ADTypes, NonlinearSolve, OrdinaryDiffEq, SciMLSensitivity
+using OrdinaryDiffEqAdamsBashforthMoulton: VCAB3
+using SciMLBase: SciMLBase
 
 function loss_function(model, x, ps, st)
     y, st = model(x, ps, st)


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Problem

OrdinaryDiffEq 7.0.0 intentionally dropped its blanket solver re-exports (cutting deps 30 -> 6 for faster TTFS; see ODE NEWS.md). The documented downstream migration is to import non-default solvers from their sub-packages.

`test/layers_tests.jl` relied on two names that ODE7 no longer exports, so the file threw `UndefVarError` at load time under ODE7:

- `VCAB3()` (line 14, in the `SOLVERS` tuple) — moved to `OrdinaryDiffEqAdamsBashforthMoulton`.
- `SciMLBase.AbstractODEAlgorithm` (multiscale `:node` branch) — the bare `SciMLBase` module name is no longer re-exported by OrdinaryDiffEq.

## Fix

- `test/layers_tests.jl`: `using OrdinaryDiffEqAdamsBashforthMoulton: VCAB3` and `using SciMLBase: SciMLBase`.
- `Project.toml`: add `OrdinaryDiffEqAdamsBashforthMoulton` to `[extras]`, the `test` target, and `[compat]` (`"1, 2"` so the package still resolves under both ODE6 and ODE7, keeping the downgrade workflow green).

Minimal change; no source files touched. `Tsit5` (still exported by ODE7) and the other solvers in the tuple were unaffected.

## Verification

Ran the full CPU suite locally on Julia 1.10 at latest deps (resolved `OrdinaryDiffEq v7.0.0`):

```
Test Summary: | Pass  Total   Time
Utils Tests   |   13     13  51.3s
Test Summary: | Pass  Total      Time
Layers Tests  | 1538   1538  22m20.7s
     Testing DeepEquilibriumNetworks tests passed
```

Confirmed the `UndefVarError` reproduces on unmodified `main` at the same deps and is gone with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)