### PR TITLE
Document DEQs public alias

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,11 @@ bib = CitationBibliography(joinpath(@__DIR__, "ref.bib"); style = :authoryear)
 
 include("pages.jl")
 
+# Documenter canonicalizes module-valued alias docs to the target module during missing-docs
+# checks, so `DEQs` cannot be counted by a canonical `@docs` block. It is documented on the
+# API page instead.
+delete!(Docs.meta(DeepEquilibriumNetworks), Docs.Binding(DeepEquilibriumNetworks, :DEQs))
+
 makedocs(;
     sitename = "Deep Equilibrium Networks",
     authors = "Avik Pal et al.",

--- a/src/DeepEquilibriumNetworks.jl
+++ b/src/DeepEquilibriumNetworks.jl
@@ -22,6 +22,12 @@ using SteadyStateDiffEq: DynamicSS, SSRootfind
 
 # Useful Constants
 const CRC = ChainRulesCore
+"""
+    DEQs
+
+Alias for the `DeepEquilibriumNetworks` module. Use it for qualified access, such as
+`DEQs.DeepEquilibriumNetwork`.
+"""
 const DEQs = DeepEquilibriumNetworks
 
 include("layers.jl")


### PR DESCRIPTION
## Summary

This PR completes the public API documentation audit for the exported `DEQs` module alias. It adds a source docstring at the alias definition and keeps the rendered API-page coverage for the alias.

Documenter currently canonicalizes module-valued alias doc objects to the aliased module during `missing_docs`, so `@docs DeepEquilibriumNetworks.DEQs` cannot satisfy the `DeepEquilibriumNetworks.DEQs` binding. The docs build now drops that single alias binding from Documenter metadata and relies on the existing API prose for rendered docs coverage.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Validation

- `git diff --check`
- Runic.jl 1.7.0 check on `src/DeepEquilibriumNetworks.jl` and `docs/make.jl`
- Julia exported-docstring audit for explicit exported names: `DEQs`, `DeepEquilibriumNetwork`, `DeepEquilibriumSolution`, `MultiScaleDeepEquilibriumNetwork`, `MultiScaleNeuralODE`, `MultiScaleSkipDeepEquilibriumNetwork`, `SkipDeepEquilibriumNetwork`; result: no undocumented exports
- `julia +1.10 --project=docs -e 'using Pkg; Pkg.instantiate(); include("docs/make.jl")'` passed locally. It emitted existing warnings for arXiv HTTP redirects, a large generated tutorial page, and skipped deployment outside CI.\n- `Pkg.test()` was attempted and fails before layer assertions because `OrdinaryDiffEq` fails to precompile: `OrdinaryDiffEqBDF` cannot import `OrdinaryDiffEqCore.find_algebraic_vars_eqs`. The same failure reproduces on clean `origin/main` at `ad4f946`, so it is pre-existing and tracked in #224.