### PR TITLE
Pin GPU tests to Volta-compatible cuDNN

### DIFF
--- a/LocalPreferences.toml
+++ b/LocalPreferences.toml
@@ -1,0 +1,2 @@
+[CUDA_Runtime_jll]
+version = "12.9"

--- a/Project.toml
+++ b/Project.toml
@@ -29,6 +29,7 @@ CommonSolve = "0.2"
 ConcreteStructs = "0.2"
 # cuDNN 9.11 dropped Volta support, but the GPU runner pool includes V100s.
 CUDNN_jll = "=9.10.0"
+CUDA_Runtime_jll = "0.19"
 DiffEqBase = "6.176.0, 7.0"
 Documenter = "1"
 FastClosures = "0.3"
@@ -63,6 +64,7 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CUDNN_jll = "62b44479-cb7b-5706-934f-f13b2eb2e645"
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
@@ -83,4 +85,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "CUDNN_jll", "Documenter", "ForwardDiff", "Functors", "GPUArraysCore", "InteractiveUtils", "LuxCUDA", "LuxTestUtils", "MLDataDevices", "NLsolve", "NonlinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqAdamsBashforthMoulton", "SafeTestsets", "SciMLSensitivity", "SciMLTesting", "StableRNGs", "Test", "Zygote"]
+test = ["Aqua", "CUDNN_jll", "CUDA_Runtime_jll", "Documenter", "ForwardDiff", "Functors", "GPUArraysCore", "InteractiveUtils", "LuxCUDA", "LuxTestUtils", "MLDataDevices", "NLsolve", "NonlinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqAdamsBashforthMoulton", "SafeTestsets", "SciMLSensitivity", "SciMLTesting", "StableRNGs", "Test", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -27,6 +27,8 @@ Aqua = "0.8"
 ChainRulesCore = "1"
 CommonSolve = "0.2"
 ConcreteStructs = "0.2"
+# cuDNN 9.11 dropped Volta support, but the GPU runner pool includes V100s.
+CUDNN_jll = "=9.10.0"
 DiffEqBase = "6.176.0, 7.0"
 Documenter = "1"
 FastClosures = "0.3"
@@ -60,6 +62,7 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CUDNN_jll = "62b44479-cb7b-5706-934f-f13b2eb2e645"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
@@ -80,4 +83,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "Documenter", "ForwardDiff", "Functors", "GPUArraysCore", "InteractiveUtils", "LuxCUDA", "LuxTestUtils", "MLDataDevices", "NLsolve", "NonlinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqAdamsBashforthMoulton", "SafeTestsets", "SciMLSensitivity", "SciMLTesting", "StableRNGs", "Test", "Zygote"]
+test = ["Aqua", "CUDNN_jll", "Documenter", "ForwardDiff", "Functors", "GPUArraysCore", "InteractiveUtils", "LuxCUDA", "LuxTestUtils", "MLDataDevices", "NLsolve", "NonlinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqAdamsBashforthMoulton", "SafeTestsets", "SciMLSensitivity", "SciMLTesting", "StableRNGs", "Test", "Zygote"]

--- a/test/shared_testsetup.jl
+++ b/test/shared_testsetup.jl
@@ -20,14 +20,17 @@ function cuda_testing()
         MLDataDevices.functional(CUDADevice)
 end
 
+if BACKEND_GROUP == "all" || BACKEND_GROUP == "cuda"
+    @test Base.pkgversion(CUDNN_jll) < v"9.11"
+    @test cuda_testing()
+end
+
 const MODES = begin
     modes = []
     cpu_testing() && push!(modes, ("cpu", Array, CPUDevice(), false))
     cuda_testing() && push!(modes, ("cuda", CuArray, CUDADevice(), true))
     modes
 end
-
-cuda_testing() && @test Base.pkgversion(CUDNN_jll) < v"9.11"
 
 is_finite_gradient(x::AbstractArray) = all(isfinite, x)
 is_finite_gradient(::Nothing) = true

--- a/test/shared_testsetup.jl
+++ b/test/shared_testsetup.jl
@@ -9,7 +9,7 @@ LuxTestUtils.jet_target_modules!(["DeepEquilibriumNetworks", "Lux", "LuxLib"])
 const BACKEND_GROUP = lowercase(get(ENV, "BACKEND_GROUP", get(ENV, "GROUP", "cpu")))
 
 if BACKEND_GROUP == "all" || BACKEND_GROUP == "cuda"
-    using LuxCUDA
+    using CUDNN_jll, LuxCUDA
 end
 
 GPUArraysCore.allowscalar(false)
@@ -26,6 +26,8 @@ const MODES = begin
     cuda_testing() && push!(modes, ("cuda", CuArray, CUDADevice(), true))
     modes
 end
+
+cuda_testing() && @test Base.pkgversion(CUDNN_jll) < v"9.11"
 
 is_finite_gradient(x::AbstractArray) = all(isfinite, x)
 is_finite_gradient(::Nothing) = true

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -5,6 +5,7 @@ versions = ["lts", "1"]
 versions = ["lts", "1"]
 
 [GPU]
-versions = ["1"]
+# CUDA.jl 5.8 is required by Volta-compatible cuDNN 9.10 and cannot target sm_70 on Julia 1.12.
+versions = ["1.10"]
 runner = ["self-hosted", "Linux", "X64", "gpu"]
 timeout = 240


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

Follow-up to #226.

## Root cause

The failure is runner-dependent rather than caused by #226:

- the matching green main GPU job ran on a T4;
- failing main and pre-#226 jobs ran on V100s;
- all resolved CUDA 6.2.1, cuDNN.jl 6.2.1, and CUDNN_jll 9.24.0;
- NVIDIA removed Volta support in [cuDNN 9.11](https://docs.nvidia.com/deeplearning/cudnn/backend/v9.11.0/release-notes.html), while the generic `gpu` runner label can select V100 (compute capability 7.0) hosts.

The unsupported stack fails convolution with `CUDNN_STATUS_EXECUTION_FAILED_CUDART`.

## Change

- Pin the test-only `CUDNN_jll` dependency to 9.10.0, the latest registered pre-9.11 release.
- Select CUDA runtime 12.9 through CUDA.jl's documented `CUDA_Runtime_jll` preference so the matching cuDNN artifact is available.
- Run the GPU group on Julia 1.10, the package's minimum supported Julia release. CUDNN_jll 9.10 requires CUDA.jl 5.8 through registered compat, and that stack emits unsupported sm_80 PTX instructions when Julia 1.12 targets the V100's sm_70 architecture.
- Assert both the cuDNN version boundary and a functional CUDA+cuDNN device in GPU mode.

This preserves the complete GPU suite; no test is skipped, disabled, or weakened. Current Julia remains covered by Core and QA, and the hard functional check prevents a GPU job from passing with zero layer tests.

These constraints apply to the test target/environment and do not constrain package users.

## Local validation

- `GROUP=Core julia +1.12 --project -e 'using Pkg; Pkg.test()'`
  - Utils: 13/13 passed
  - Layers: 1538/1538 passed
  - exit 0
- `GROUP=GPU julia +1.10 --project -e 'using Pkg; Pkg.test()'`
  - resolved and precompiled CUDA 12.9 runtime, CUDNN_jll 9.10.0+0, cuDNN.jl 1.4.4, and CUDA.jl 5.8.5
  - Utils: 9 passed and the intentional `@test cuda_testing()` device guard failed on this CPU-only host
  - the self-hosted GPU CI job is required for passing device execution
- `julia +1.12 -m Runic --check --diff .`
- `git diff --check`

## CI evidence

The prior revision ran on an actual V100: the functional guard passed and Utils passed 15/15, proving the pinned runtime/cuDNN artifact loaded. Its original cuDNN execution error disappeared. It then exposed a separate Julia 1.12/CUDA.jl 5.8 PTX failure (`Modifier '.NaN' requires .target sm_80 or higher`) while compiling for sm_70, which is why the GPU group now uses Julia 1.10.

The final CI result is valid only if the GPU Layers test count is nonzero.
