### PR TITLE
Release prep: bump DeepEquilibriumNetworks to 2.7.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DeepEquilibriumNetworks"
 uuid = "6748aba7-0e9b-415e-a410-ae3cc0ecb334"
 authors = ["Avik Pal <avikpal@mit.edu>"]
-version = "2.7.2"
+version = "2.7.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Patch release covering the accumulated docstring/QA/test-scaffolding changes since 2.7.2 (no functional or public-API changes).