### PR TITLE
Release prep: bump version to 2.7.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DeepEquilibriumNetworks"
 uuid = "6748aba7-0e9b-415e-a410-ae3cc0ecb334"
 authors = ["Avik Pal <avikpal@mit.edu>"]
-version = "2.7.3"
+version = "2.7.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
## Summary

Bumps the package version from 2.7.3 to 2.7.4 to release the one commit that has landed since the last registered release (which was tagged at commit 14a3aef).

## What changed since v2.7.3

- `test/test_groups.toml`: added `gpu-v100` to the self-hosted GPU CI runner label list (9ee48db).

No source files, public API, or `[compat]` bounds changed since the last release.

## Bump type: PATCH (2.7.3 -> 2.7.4)

The only change is a CI runner configuration tweak (test infrastructure), with no effect on package behavior or public API. This falls squarely under a PATCH-level change per the release-prep policy (docs/tests/CI-only changes => PATCH).

## Compat bounds

Not touched — the diff does not add or exercise any new APIs from SciML-ecosystem (or other) dependencies, so existing `[compat]` lower bounds remain accurate.