### PR TITLE
Use strict SciMLTesting 2.4 QA

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,23 +1,21 @@
 using Documenter, DocumenterCitations, DeepEquilibriumNetworks
 
-cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml"; force = true)
-cp("./docs/Project.toml", "./docs/src/assets/Project.toml"; force = true)
-
 bib = CitationBibliography(joinpath(@__DIR__, "ref.bib"); style = :authoryear)
 
 include("pages.jl")
 
-# Documenter canonicalizes module-valued alias docs to the target module during missing-docs
-# checks, so `DEQs` cannot be counted by a canonical `@docs` block. It is documented on the
-# API page instead.
-delete!(Docs.meta(DeepEquilibriumNetworks), Docs.Binding(DeepEquilibriumNetworks, :DEQs))
+DocMeta.setdocmeta!(
+    DeepEquilibriumNetworks, :DocTestSetup, quote
+        using DeepEquilibriumNetworks, Lux, NonlinearSolve, Random, SteadyStateDiffEq
+    end; recursive = true
+)
 
 makedocs(;
     sitename = "Deep Equilibrium Networks",
     authors = "Avik Pal et al.",
     modules = [DeepEquilibriumNetworks],
     clean = true,
-    doctest = false,  # Tested in CI
+    doctest = true,
     linkcheck = true,
     format = Documenter.HTML(;
         assets = ["assets/favicon.ico"],

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -47,25 +47,13 @@ recommend:
     `sensealg = SteadyStateAdjoint()` or
     `sensealg = SteadyStateAdjoint(; linsolve = LUFactorization())` for small models.
 
-## Standard Models
-
-`DEQs` is exported as an alias for the `DeepEquilibriumNetworks` module.
+## Public API
 
 ```@docs
-DeepEquilibriumNetwork
-SkipDeepEquilibriumNetwork
+DEQs
 ```
 
-## MultiScale Models
-
-```@docs
-MultiScaleDeepEquilibriumNetwork
-MultiScaleSkipDeepEquilibriumNetwork
-MultiScaleNeuralODE
-```
-
-## Solution
-
-```@docs
-DeepEquilibriumSolution
+```@autodocs
+Modules = [DeepEquilibriumNetworks]
+Private = false
 ```

--- a/src/DeepEquilibriumNetworks.jl
+++ b/src/DeepEquilibriumNetworks.jl
@@ -25,8 +25,14 @@ const CRC = ChainRulesCore
 """
     DEQs
 
-Alias for the `DeepEquilibriumNetworks` module. Use it for qualified access, such as
-`DEQs.DeepEquilibriumNetwork`.
+Alias for the `DeepEquilibriumNetworks` module.
+
+## Example
+
+```jldoctest
+julia> DEQs === DeepEquilibriumNetworks
+true
+```
 """
 const DEQs = DeepEquilibriumNetworks
 

--- a/src/layers.jl
+++ b/src/layers.jl
@@ -102,11 +102,9 @@ field contains a [`DeepEquilibriumSolution`](@ref).
 ## Example
 
 ```jldoctest
-julia> using DeepEquilibriumNetworks, Lux, SteadyStateDiffEq, Random
-
 julia> model = DeepEquilibriumNetwork(
            Parallel(+, Dense(2, 2; use_bias=false), Dense(2, 2; use_bias=false)),
-           SSRootfind(); verbose=false);
+           NewtonRaphson(); verbose=false);
 
 julia> rng = Xoshiro(0);
 
@@ -247,11 +245,9 @@ Returns a [`DeepEquilibriumNetwork`](@ref).
 ## Example
 
 ```jldoctest
-julia> using DeepEquilibriumNetworks, Lux, SteadyStateDiffEq, Random
-
 julia> model = SkipDeepEquilibriumNetwork(
            Parallel(+, Dense(2, 2; use_bias=false), Dense(2, 2; use_bias=false)),
-           SSRootfind(); verbose=false);
+           NewtonRaphson(); verbose=false);
 
 julia> ps, st = Lux.setup(Xoshiro(0), model);
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,23 +1,9 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DeepEquilibriumNetworks = "6748aba7-0e9b-415e-a410-ae3cc0ecb334"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
-NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
-SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
-Documenter = "1"
-Lux = "1"
-NonlinearSolve = "4"
-OrdinaryDiffEq = "6.74, 7"
-Random = "1.10"
 SciMLTesting = "2.4"
-SteadyStateDiffEq = "2.5.0"
-Test = "1.10"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,22 +1,3 @@
-using SciMLTesting, DeepEquilibriumNetworks, Test
+using SciMLTesting, DeepEquilibriumNetworks
 
-run_qa(
-    DeepEquilibriumNetworks;
-    # Documenter canonicalizes this module alias to the target module binding.
-    api_docs_kwargs = (; rendered_ignore = (:DEQs,)),
-    # `Aqua.test_all`'s default ambiguities check recurses into deps and is noisy; run
-    # it only against this package's own methods (the prior hand-rolled qa.jl disabled
-    # the recursive sweep and called `test_ambiguities(...; recursive = false)`).
-    aqua_kwargs = (; ambiguities = (; recursive = false)),
-)
-
-@testset "Doctests" begin
-    using Documenter
-
-    doctestexpr = quote
-        using DeepEquilibriumNetworks, Lux, Random, OrdinaryDiffEq, NonlinearSolve
-    end
-
-    DocMeta.setdocmeta!(DeepEquilibriumNetworks, :DocTestSetup, doctestexpr; recursive = true)
-    doctest(DeepEquilibriumNetworks; manual = false)
-end
+run_qa(DeepEquilibriumNetworks)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Removes repository-specific QA exceptions and source-path copies, enables normal Documenter doctests, and renders the public API including the `DEQs` alias.

Validation:
- Julia 1.12 `Pkg.test()`
- strict `run_qa(DeepEquilibriumNetworks)`
- full docs build with doctests, checkdocs, rendered public docs, and link checking
- `Runic --check src test docs`
- `git diff --check`