### PR TITLE
Drop unused NLsolve test extra

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,6 @@ LuxCUDA = "0.3"
 LuxCore = "1"
 LuxTestUtils = "2"
 MLDataDevices = "1"
-NLsolve = "5"
 NNlib = "0.9"
 NonlinearSolve = "4"
 NonlinearSolveBase = "2"
@@ -69,7 +68,6 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LuxCUDA = "d0bbae9a-e099-4d5b-a835-1c6931763bda"
 LuxTestUtils = "ac9de150-d08f-4546-94fb-7472b5760531"
 MLDataDevices = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
-NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqAdamsBashforthMoulton = "89bda076-bce5-4f1c-845f-551c83cdda9a"
@@ -80,4 +78,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "Documenter", "ForwardDiff", "Functors", "GPUArraysCore", "InteractiveUtils", "LuxCUDA", "LuxTestUtils", "MLDataDevices", "NLsolve", "NonlinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqAdamsBashforthMoulton", "SafeTestsets", "SciMLSensitivity", "SciMLTesting", "StableRNGs", "Test", "Zygote"]
+test = ["Aqua", "Documenter", "ForwardDiff", "Functors", "GPUArraysCore", "InteractiveUtils", "LuxCUDA", "LuxTestUtils", "MLDataDevices", "NonlinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqAdamsBashforthMoulton", "SafeTestsets", "SciMLSensitivity", "SciMLTesting", "StableRNGs", "Test", "Zygote"]


### PR DESCRIPTION
Drop unused NLsolve from `[extras]` / `[targets].test` / `[compat]`. Tests use `NewtonRaphson` and `SimpleLimitedMemoryBroyden` from NonlinearSolve, not NLsolve. NLsolve was only pulled so `NonlinearSolveNLsolveExt` would load.

Registered NonlinearSolve 4.x WeakCompat is `NLsolve = "4.5.0-4"` (`["3 - 4.9"]` and `["4.10 - 4"]` in General). NLsolve 5 is live. With NLsolve kept as a test extra, Downgrade promotes extras into the merged resolve, so `--min=@deps` requires NLsolve 5 next to NonlinearSolve 4 and is unsatisfiable. https://github.com/SciML/NonlinearSolve.jl/pull/1198 set `NLsolve = "5"` in source; that is not registered yet (latest NS is 4.28.0, still pinned to NLsolve 4.5-4).

This supersedes https://github.com/SciML/DeepEquilibriumNetworks.jl/pull/241 (`NLsolve = "4, 5"`), which keeps extra major 4 so the min floor can still pick 4.5.1. NLsolve is unused here, so the extra should go rather than keep major 4.

| file | change |
|---|---|
| `Project.toml` | remove `NLsolve` from `[compat]`, `[extras]`, `[targets].test` |

NonlinearSolve stays at `"4"`.

## Verification

Local Julia 1.10.11. Resolver.jl `--min=@deps --julia=1.10` on a merged extras project (same extras-to-deps promotion as julia-downgrade-compat):

**Before** (`origin/main`, `NLsolve = "5"` extra): Unsatisfiable

```
Unsatisfiable — 1 conflict:

Conflict 1: NLsolve, NonlinearSolve and OrdinaryDiffEqAdamsBashforthMoulton cannot all be satisfied.
  • you require NLsolve
  • you require NonlinearSolve
  • you require OrdinaryDiffEqAdamsBashforthMoulton
  • NonlinearSolve 4.0.0–4.25.0 works with NLsolve only at 4.5.0–4.5.1
  • your compat leaves NLsolve at ≥ 5.0.0
  Fix it by any one of:
    1. relax your compat on NLsolve
       → allows: NLsolve 4.5.1, NonlinearSolve 4.17.1,
         OrdinaryDiffEqAdamsBashforthMoulton 2.0.0
    2. drop requirement NLsolve
       → allows: NonlinearSolve 4.17.1, OrdinaryDiffEqAdamsBashforthMoulton
         2.0.0
```

**After** (NLsolve extra removed): EXIT 0. NLsolve is not in the resolved set. Direct floors include NonlinearSolve 4.17.1, OrdinaryDiffEq 7.0.0, OrdinaryDiffEqAdamsBashforthMoulton 2.0.0, ForwardDiff 1.0.1, Lux 1.16.0, SciMLSensitivity 7.105.0.

`GROUP=Core` `Pkg.test()` without NLsolve extra (test env Status has NonlinearSolve v4.28.0 and no NLsolve):

```
Test Summary: | Pass  Total     Time
Utils Tests   |   13     13  1m01.3s
Test Summary: | Pass  Total      Time
Layers Tests  | 1538   1538  24m19.3s
     Testing DeepEquilibriumNetworks tests passed
```

Started 2026-08-26T11:07:27-04:00, finished 2026-08-26T11:38:44-04:00.

## Not verified

- GPU group (self-hosted CUDA)
- QA group
- docs build (no docstring / `docs/` / public API change)
- Downstream

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
