### PR TITLE
Avoid ForwardDiff Jacobians for GPU steady-state adjoints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 FastClosures = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"
+GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 LuxCore = "bb33d45b-7691-41d6-9220-0943567d0623"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
@@ -62,7 +63,6 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
-GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LuxCUDA = "d0bbae9a-e099-4d5b-a835-1c6931763bda"
@@ -78,4 +78,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "Documenter", "ForwardDiff", "Functors", "GPUArraysCore", "InteractiveUtils", "LuxCUDA", "LuxTestUtils", "MLDataDevices", "NonlinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqAdamsBashforthMoulton", "SafeTestsets", "SciMLSensitivity", "SciMLTesting", "StableRNGs", "Test", "Zygote"]
+test = ["Aqua", "Documenter", "ForwardDiff", "Functors", "InteractiveUtils", "LuxCUDA", "LuxTestUtils", "MLDataDevices", "NonlinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqAdamsBashforthMoulton", "SafeTestsets", "SciMLSensitivity", "SciMLTesting", "StableRNGs", "Test", "Zygote"]

--- a/src/DeepEquilibriumNetworks.jl
+++ b/src/DeepEquilibriumNetworks.jl
@@ -7,6 +7,7 @@ using ConcreteStructs: @concrete
 using DiffEqBase: DiffEqBase
 using NonlinearSolveBase: AbsNormTerminationMode
 using FastClosures: @closure
+using GPUArraysCore: AbstractGPUArray
 using Random: Random, AbstractRNG, randn!
 using SciMLBase: SciMLBase, AbstractNonlinearAlgorithm, AbstractODEAlgorithm,
     NonlinearSolution, ODESolution, ODEFunction, ODEProblem,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -90,10 +90,11 @@ zeros_init(::Nothing, x::AbstractArray) = zero(x)
 CRC.@non_differentiable zeros_init(::Any, ::Any)
 
 ## Don't rely on SciMLSensitivity's choice
-function default_sensealg(::SteadyStateProblem)
+function default_sensealg(prob::SteadyStateProblem)
     # Ideally we should use GMRES here, but it is not very robust
     return SteadyStateAdjoint(;
         linsolve = nothing, linsolve_kwargs = (; maxiters = 10, abstol = 1.0e-3, reltol = 1.0e-3),
+        autodiff = !(prob.u0 isa AbstractGPUArray),
         autojacvec = ZygoteVJP()
     )
 end

--- a/test/utils_tests.jl
+++ b/test/utils_tests.jl
@@ -1,6 +1,14 @@
 include("shared_testsetup.jl")
 
 using SciMLBase
+using GPUArraysCore: AbstractGPUArray
+using SciMLSensitivity: SteadyStateAdjoint
+
+struct MockGPUVector{T} <: AbstractGPUArray{T, 1}
+    data::Vector{T}
+end
+Base.size(x::MockGPUVector) = size(x.data)
+Base.getindex(x::MockGPUVector, i::Int) = x.data[i]
 
 @testset "split_and_reshape" begin
     for (mode, aType, dev, ongpu) in MODES
@@ -31,6 +39,13 @@ end
 @testset "get unrolled_mode" begin
     @test DEQs.get_unrolled_depth(Val(10)) == 10
     @test DEQs.get_unrolled_depth((; fixed_depth = Val(10))) == 10
+end
+
+@testset "steady-state sensitivity defaults" begin
+    cpu_prob = SteadyStateProblem((u, p, t) -> u, zeros(2))
+    gpu_prob = SteadyStateProblem((u, p, t) -> u, MockGPUVector(zeros(2)))
+    @test DEQs.default_sensealg(cpu_prob) isa SteadyStateAdjoint{0, true}
+    @test DEQs.default_sensealg(gpu_prob) isa SteadyStateAdjoint{0, false}
 end
 
 @testset "deep equilibrium solution" begin


### PR DESCRIPTION
> **Please ignore this draft until it has been reviewed by @ChrisRackauckas.**

## What changed and why

DeepEquilibriumNetworks overrides SciMLSensitivity's automatic steady-state sense-algorithm choice, but its override left `autodiff=true` for GPU states. ForwardDiff 1.4.4 began zeroing the unused tail of chunked dual arrays with scalar indexing, so constructing the steady-state adjoint Jacobian now fails on `CuArray`.

Select `autodiff=false` only when the steady-state problem's initial state is an `AbstractGPUArray`, matching SciMLSensitivity's own GPU-specific choice while preserving ForwardDiff Jacobians for CPU states. GPUArraysCore moves from a test extra to a direct dependency because runtime dispatch now uses its public `AbstractGPUArray` interface.

## Regression boundary

The current main failure resolves ForwardDiff 1.4.5 and SciMLSensitivity 7.119.0, then errors in `ForwardDiff._seed_zero_partials!` with `Scalar indexing is disallowed`:

- failing main run: https://github.com/SciML/DeepEquilibriumNetworks.jl/actions/runs/32990908259
- failing GPU job: https://github.com/SciML/DeepEquilibriumNetworks.jl/actions/runs/32990908259/job/98277422908

The previous GPU run resolved ForwardDiff 1.4.3 and SciMLSensitivity 7.116.2; its dense steady-state adjoint cases cleared this error before the job later failed in an unrelated V100 cuDNN convolution:

- previous run: https://github.com/SciML/DeepEquilibriumNetworks.jl/actions/runs/30374833857
- previous GPU job: https://github.com/SciML/DeepEquilibriumNetworks.jl/actions/runs/30374833857/job/90328502950

ForwardDiff 1.4.4 introduced the chunk-tail zeroing path:

- release: https://github.com/JuliaDiff/ForwardDiff.jl/releases/tag/v1.4.4
- implementation PR: https://github.com/JuliaDiff/ForwardDiff.jl/pull/821

There were no repository GPU runs between those dependency resolutions, so the resolved dependency boundary, rather than a DeepEquilibriumNetworks commit, is the narrowest available boundary.

## Verification

Failing before the source fix, with the new regression test present:

```text
steady-state sensitivity defaults: Test Failed at test/utils_tests.jl:48
  Expression: DEQs.default_sensealg(gpu_prob) isa SteadyStateAdjoint{0, false}
   Evaluated: SciMLSensitivity.SteadyStateAdjoint{0, true, ...} isa
              SciMLSensitivity.SteadyStateAdjoint{0, false}

Test Summary:                       | Pass  Fail  Total   Time
Utils Tests                         |   14     1     15  59.8s
  steady-state sensitivity defaults |    1     1      2   3.5s
ERROR: Some tests did not pass: 14 passed, 1 failed, 0 errored, 0 broken.
```

Passing after the fix:

```text
$ GROUP=Core julia +release --project=. -e 'using Pkg; Pkg.resolve(); Pkg.test()'
Test Summary: | Pass  Total   Time
Utils Tests   |   15     15  58.2s
Test Summary: | Pass  Total      Time
Layers Tests  | 1538   1538  26m27.2s
Testing DeepEquilibriumNetworks tests passed
```

```text
$ GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   20     20  2m03.6s
Testing DeepEquilibriumNetworks tests passed
```

The following also exited successfully with no output:

```text
julia +release -m Runic --inplace src/DeepEquilibriumNetworks.jl src/utils.jl test/utils_tests.jl
typos Project.toml src/DeepEquilibriumNetworks.jl src/utils.jl test/utils_tests.jl
git diff --check
```

GPUArraysCore is MIT-licensed, compatible with this MIT-licensed package.

## GPU CI classification

The PR's GPU job completed with 578 passes and 48 errors. None of the remaining errors follows the path changed here:

- The clean-base failure uses `ForwardDiff.Tag{SciMLBase.UDerivativeWrapper...}` while constructing `SteadyStateAdjointProblem`. The PR job has zero `UDerivativeWrapper` occurrences, and the new default-sense-algorithm regression passes 15/15.
- Twelve errors use `ForwardDiff.Tag{SciMLBase.NonlinearFunction...}` in the forward solve. They come from the pre-existing test configuration `NewtonRaphson(; autodiff=AutoForwardDiff(; chunksize=12))`, introduced in https://github.com/SciML/DeepEquilibriumNetworks.jl/commit/a30d8f1af63d85820e17369c9dc2339ef4cbffd2, and are independent of the default adjoint selected by this PR.
  A separate focused repair changes that explicit GPU Newton configuration to `AutoFiniteDiff()` in https://github.com/SciML/DeepEquilibriumNetworks.jl/pull/244; it is intentionally not mixed into this adjoint fix.
- Thirty-six errors are `CUDNN_STATUS_EXECUTION_FAILED_CUDART` from NNlib/cuDNN forward convolutions in untouched layer and test code. The clean-base job stopped at the original adjoint error before reaching those later cases; the base and PR jobs nevertheless resolve identical GPUArraysCore, Lux, LuxCUDA, NNlib, CUDA, cuDNN, and JLL versions.

GPU job: https://github.com/SciML/DeepEquilibriumNetworks.jl/actions/runs/33104383320/job/98635451731

## Not verified locally

This host has no CUDA-capable GPU. The regression test verifies the CPU/GPU dispatch decision using an `AbstractGPUArray` test double; the GPU conclusions above come from the clean-base and PR CI logs. Documentation was not built because this does not change public API or documentation.

## Related documentation fix

The clean-main `DEQs` documentation failure is addressed separately in https://github.com/SciML/DeepEquilibriumNetworks.jl/pull/245.

🤖 Generated with Codex CLI 0.150.1 (model: unknown; session: 01a0441e-3d2f-7170-ab6e-58ef72975a9f)