### PR TITLE
Use finite differences for GPU Newton tests

### DIFF
--- a/test/layers_tests.jl
+++ b/test/layers_tests.jl
@@ -12,10 +12,15 @@ function loss_function(model, x, ps, st)
     return l1 + l2 + l3
 end
 
-const SOLVERS = (
-    VCAB3(), Tsit5(), NewtonRaphson(; autodiff = AutoForwardDiff(; chunksize = 12)),
-    SimpleLimitedMemoryBroyden(),
-)
+function solvers(ongpu)
+    autodiff = ongpu ? AutoFiniteDiff() : AutoForwardDiff(; chunksize = 12)
+    return VCAB3(), Tsit5(), NewtonRaphson(; autodiff), SimpleLimitedMemoryBroyden()
+end
+
+@testset "Solver autodiff configuration" begin
+    @test solvers(false)[3].autodiff isa AutoForwardDiff
+    @test solvers(true)[3].autodiff isa AutoFiniteDiff
+end
 
 @testset "DEQ" begin
     rng = StableRNG(0)
@@ -35,7 +40,7 @@ const SOLVERS = (
             _jacobian_regularizations
 
         @testset "Solver: $(nameof(typeof(solver))) | Model Type: $(mtype) | Jac. Reg: $(jacobian_regularization)" for solver in
-                SOLVERS,
+                solvers(ongpu),
                 mtype in model_type, jacobian_regularization in jacobian_regularizations
 
             @testset "x_size: $(x_size)" for (base_model, init_model, x_size) in
@@ -116,7 +121,7 @@ end
     jacobian_regularizations = (nothing,)
 
     @testset "$mode" for (mode, aType, dev, ongpu) in MODES
-        @testset "Solver: $(nameof(typeof(solver)))" for solver in SOLVERS,
+        @testset "Solver: $(nameof(typeof(solver)))" for solver in solvers(ongpu),
                 mtype in model_type, jacobian_regularization in jacobian_regularizations
 
             @testset "x_size: $(x_size)" for (


### PR DESCRIPTION
## What changed

The GPU layer-test matrix now configures `NewtonRaphson` with `AutoFiniteDiff`, while the CPU matrix retains its existing `AutoForwardDiff(chunksize=12)` coverage. Assertions guard both backend choices.

ForwardDiff seeds dual arrays through scalar indexing, which is unsupported for CUDA arrays. NonlinearSolve uses `AutoFiniteDiff` for the same Newton CUDA coverage. This is intentionally separate from https://github.com/SciML/DeepEquilibriumNetworks.jl/pull/243 and should be reviewed and landed with or after that prerequisite.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failing before

With the old GPU configuration retained, the new regression assertion failed:

```text
Solver autodiff configuration: Test Failed at test/layers_tests.jl:22
  Expression: ((solvers(true))[3]).autodiff isa AutoFiniteDiff
   Evaluated: ADTypes.AutoForwardDiff(chunksize=12) isa ADTypes.AutoFiniteDiff
```

The runtime symptom is independently visible as 12 `GPUArraysCore` scalar-indexing errors from `ForwardDiff._seed_zero_partials!` and `SciMLBase.NonlinearFunction` in the GPU job for https://github.com/SciML/DeepEquilibriumNetworks.jl/pull/243:
https://github.com/SciML/DeepEquilibriumNetworks.jl/actions/runs/33104383320/job/98635451731

## Passing after

```text
$ GROUP=Core julia +1.11 --project=. -e "using Pkg; Pkg.test()"
Test Summary: | Pass  Total      Time
Layers Tests  | 1540   1540  29m34.8s
Testing DeepEquilibriumNetworks tests passed

$ GROUP=QA julia +1.11 --project=. -e "using Pkg; Pkg.test()"
Test Summary: | Pass  Total     Time
QA            |   20     20  1m34.1s
Testing DeepEquilibriumNetworks tests passed

$ julia +1.11 --project=@runic -e "using Runic; exit(Runic.main([\"--check\", \"test/layers_tests.jl\"]))"
# exit 0

$ git diff --no-ext-diff -- test/layers_tests.jl | typos -
# exit 0

$ git diff --check
# exit 0
```

## Not verified locally

No NVIDIA GPU is available on this host, so the full CUDA matrix was not run locally. GPU CI on this branch may remain blocked by the clean-main SteadyStateAdjoint failure until https://github.com/SciML/DeepEquilibriumNetworks.jl/pull/243 lands.

The 36 cuDNN execution errors in that job are a separate forward-convolution/runtime problem in an untouched path. A standalone Lux/NNlib/CUDA reproducer was identified, but it cannot be verified on this host without a GPU, so no upstream issue was filed.

🤖 Generated with Codex CLI 0.150.1 (model: unknown; session: local session ID 01a0441e-3d2f-7170-ab6e-58ef72975a9f)