### PR TITLE
Document DEQs through its module binding

### DIFF
--- a/src/DeepEquilibriumNetworks.jl
+++ b/src/DeepEquilibriumNetworks.jl
@@ -1,3 +1,16 @@
+"""
+    DeepEquilibriumNetworks
+    DEQs
+
+The `DeepEquilibriumNetworks` module. `DEQs` is an alias for the module.
+
+## Example
+
+```jldoctest
+julia> DEQs === DeepEquilibriumNetworks
+true
+```
+"""
 module DeepEquilibriumNetworks
 
 using ADTypes: AutoFiniteDiff, AutoForwardDiff, AutoZygote
@@ -22,18 +35,6 @@ using SteadyStateDiffEq: DynamicSS, SSRootfind
 
 # Useful Constants
 const CRC = ChainRulesCore
-"""
-    DEQs
-
-Alias for the `DeepEquilibriumNetworks` module.
-
-## Example
-
-```jldoctest
-julia> DEQs === DeepEquilibriumNetworks
-true
-```
-"""
 const DEQs = DeepEquilibriumNetworks
 
 include("layers.jl")


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`DEQs` evaluates to the package module. Documenter 1.17 normalizes canonical documentation for module-valued aliases to the module binding, while its missing-docs inventory retains the alias binding, so metadata attached directly to `DEQs` cannot be counted as rendered. This moves the existing docstring to the module value and lists `DEQs` as a signature; Julia help for `DEQs` still resolves to that documentation, and the existing `@autodocs` block renders it once.

## Regression evidence

On clean upstream `a4dc3d31b3ae9cc547081132ed0a109ea710f614`, I ran:

```console
TMPDIR="$HOME/tmp" timeout 3600 julia +release --project=docs docs/make.jl
```

and observed:

```text
Error: 1 docstring not included in the manual:
    DeepEquilibriumNetworks.DEQs
ERROR: LoadError: `makedocs` encountered an error [:missing_docs]
```

With this commit, the same command completed `Doctest` and `CheckDocument` without a missing-docs error. Its final link-check stage then encountered an unrelated transient response from GitHub:

```text
linkcheck 'https://github.com/SciML/ColPrac/blob/master/README.md' status: 429
ERROR: LoadError: `makedocs` encountered an error [:linkcheck]
```

An immediate direct request to that URL returned HTTP/2 200. A reduced strict Documenter build using the repository's real API `@docs`/`@autodocs` blocks completed successfully with `warnonly = false`.

The help/metadata check after the fix reported:

```text
module_doc=true
alias_binding_doc=true
alias_binding_meta=false
identity=true
```

This confirms that `Docs.doc(DeepEquilibriumNetworks)`, help lookup through `Docs.Binding(DeepEquilibriumNetworks, :DEQs)`, and `DEQs === DeepEquilibriumNetworks` all retain the expected behavior without leaving separate alias metadata for Documenter to miscount.

## Verification

```console
GROUP=Core TMPDIR="$HOME/tmp" timeout 3600 julia +release --project=. -e 'using Pkg; Pkg.test()'
```

```text
Utils Tests  |   13     13  1m25.2s
Layers Tests | 1538   1538 26m42.8s
Testing DeepEquilibriumNetworks tests passed
```

```console
GROUP=QA TMPDIR="$HOME/tmp" timeout 3600 julia +release --project=. -e 'using Pkg; Pkg.test()'
```

```text
QA | 20 20 2m07.7s
Testing DeepEquilibriumNetworks tests passed
```

```console
julia +release -m Runic --check src/DeepEquilibriumNetworks.jl
typos src/DeepEquilibriumNetworks.jl
git diff --check upstream/main...HEAD
```

All three commands exited 0 with no output.

## Bisect

The first bad commit is https://github.com/SciML/DeepEquilibriumNetworks.jl/commit/4e6cbafb5c199d7673ab43c593dc4c3f4061653f, which enabled strict SciMLTesting 2.4 QA and thereby exposed the already-unrenderable alias metadata.

## Not verified

The complete docs build did not finish after the unrelated external-link HTTP 429 described above. GPU tests were not run because this change only relocates existing documentation metadata.

🤖 Generated with Codex CLI 0.150.1 (model: unknown; session: local session ID 01a0441e-3d2f-7170-ab6e-58ef72975a9f)
