### PR TITLE
Use SciMLSensitivity automatic sensealg choice

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,6 @@ CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 FastClosures = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"
-GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 LuxCore = "bb33d45b-7691-41d6-9220-0943567d0623"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
@@ -63,6 +62,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
+GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LuxCUDA = "d0bbae9a-e099-4d5b-a835-1c6931763bda"
@@ -78,4 +78,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "Documenter", "ForwardDiff", "Functors", "InteractiveUtils", "LuxCUDA", "LuxTestUtils", "MLDataDevices", "NonlinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqAdamsBashforthMoulton", "SafeTestsets", "SciMLSensitivity", "SciMLTesting", "StableRNGs", "Test", "Zygote"]
+test = ["Aqua", "Documenter", "ForwardDiff", "Functors", "GPUArraysCore", "InteractiveUtils", "LuxCUDA", "LuxTestUtils", "MLDataDevices", "NonlinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqAdamsBashforthMoulton", "SafeTestsets", "SciMLSensitivity", "SciMLTesting", "StableRNGs", "Test", "Zygote"]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -38,14 +38,19 @@ recommend:
 
 ### Sensitivity Analysis
 
- 1. For `MultiScaleNeuralODE`, we default to `GaussAdjoint(; autojacvec = ZygoteVJP())`. A
-    faster alternative would be `BacksolveAdjoint(; autojacvec = ZygoteVJP())` but there are
-    stability concerns for using that. Follow the recommendation given in [SciMLSensitivity.jl](https://docs.sciml.ai/SciMLSensitivity/stable/manual/differential_equation_sensitivities/#Choosing-a-Sensitivity-Algorithm) documentation.
- 2. For Steady State Problems, we default to
-    `SteadyStateAdjoint(; linsolve = SimpleGMRES(; blocksize, linsolve_kwargs = (; maxiters=10, abstol=1e-3, reltol=1e-3)))`.
-    This default will perform poorly on small models. It is recommended to pass
-    `sensealg = SteadyStateAdjoint()` or
-    `sensealg = SteadyStateAdjoint(; linsolve = LUFactorization())` for small models.
+This package does not override SciMLSensitivity.jl's automatic `sensealg` choice.
+`solve` is called with `sensealg = nothing` unless a `sensealg` is passed through the
+layer constructor kwargs.
+
+ 1. For the out-of-place `SteadyStateProblem`s constructed here, SciMLSensitivity selects
+    `SteadyStateAdjoint(autodiff = false, autojacvec = ZygoteVJP())`. Pass
+    `sensealg = SteadyStateAdjoint(; linsolve = LUFactorization())` for small models if
+    the automatic linear solver is a poor fit.
+ 2. For `MultiScaleNeuralODE` (functor parameters), SciMLSensitivity selects
+    `GaussAdjoint(; autojacvec = ZygoteVJP())`. A faster alternative is
+    `BacksolveAdjoint(; autojacvec = ZygoteVJP())`, with the usual stability caveats.
+    See the [SciMLSensitivity.jl](https://docs.sciml.ai/SciMLSensitivity/stable/manual/differential_equation_sensitivities/#Choosing-a-Sensitivity-Algorithm)
+    documentation.
 
 ## Public API
 

--- a/src/DeepEquilibriumNetworks.jl
+++ b/src/DeepEquilibriumNetworks.jl
@@ -20,12 +20,13 @@ using ConcreteStructs: @concrete
 using DiffEqBase: DiffEqBase
 using NonlinearSolveBase: AbsNormTerminationMode
 using FastClosures: @closure
-using GPUArraysCore: AbstractGPUArray
 using Random: Random, AbstractRNG, randn!
 using SciMLBase: SciMLBase, AbstractNonlinearAlgorithm, AbstractODEAlgorithm,
     NonlinearSolution, ODESolution, ODEFunction, ODEProblem,
     SteadyStateProblem
-using SciMLSensitivity: SteadyStateAdjoint, GaussAdjoint, ZygoteVJP
+# Load SciMLSensitivity so `solve` adjoint rrules are registered. The sense
+# algorithm itself is SciMLSensitivity's automatic choice (`sensealg = nothing`).
+import SciMLSensitivity
 using Static: StaticSymbol, StaticInt, known, static
 
 using Lux: Lux, LuxOps, BranchLayer, Chain, NoOpLayer, Parallel, RepeatedLayer,

--- a/src/layers.jl
+++ b/src/layers.jl
@@ -92,7 +92,8 @@ Deep Equilibrium Network as proposed in [baideep2019](@cite) and [pal2022mixing]
     `nothing`, `AutoForwardDiff`, `AutoFiniteDiff`, and `AutoZygote`.
   - `problem_type`: Equilibrium problem type. Use `ODEProblem` to construct an ODE-based
     network; defaults to `SteadyStateProblem`.
-  - `kwargs`: Additional keyword arguments passed to `SciMLBase.solve`.
+  - `kwargs`: Additional keyword arguments passed to `SciMLBase.solve`. Omitting
+    `sensealg` uses SciMLSensitivity.jl's automatic adjoint choice.
 
 ## Returns
 
@@ -184,7 +185,7 @@ function (deq::DEQ)(x, ps, st::NamedTuple, ::Val{false})
     alg = normalize_alg(deq)
     termination_condition = AbsNormTerminationMode(Base.Fix1(maximum, abs))
     sol = solve(
-        prob, alg; sensealg = default_sensealg(prob), abstol = 1.0e-3,
+        prob, alg; sensealg = nothing, abstol = 1.0e-3,
         reltol = 1.0e-3, termination_condition, maxiters = 32, deq.kwargs...
     )
     z_star = get_steady_state(sol)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -89,17 +89,6 @@ zeros_init(::Nothing, x::AbstractArray) = zero(x)
 
 CRC.@non_differentiable zeros_init(::Any, ::Any)
 
-## Don't rely on SciMLSensitivity's choice
-function default_sensealg(prob::SteadyStateProblem)
-    # Ideally we should use GMRES here, but it is not very robust
-    return SteadyStateAdjoint(;
-        linsolve = nothing, linsolve_kwargs = (; maxiters = 10, abstol = 1.0e-3, reltol = 1.0e-3),
-        autodiff = !(prob.u0 isa AbstractGPUArray),
-        autojacvec = ZygoteVJP()
-    )
-end
-default_sensealg(::ODEProblem) = GaussAdjoint(; autojacvec = ZygoteVJP())
-
 function randn_like(rng::AbstractRNG, x::AbstractArray)
     y = similar(x)::typeof(x)
     randn!(rng, y)

--- a/test/utils_tests.jl
+++ b/test/utils_tests.jl
@@ -1,14 +1,6 @@
 include("shared_testsetup.jl")
 
 using SciMLBase
-using GPUArraysCore: AbstractGPUArray
-using SciMLSensitivity: SteadyStateAdjoint
-
-struct MockGPUVector{T} <: AbstractGPUArray{T, 1}
-    data::Vector{T}
-end
-Base.size(x::MockGPUVector) = size(x.data)
-Base.getindex(x::MockGPUVector, i::Int) = x.data[i]
 
 @testset "split_and_reshape" begin
     for (mode, aType, dev, ongpu) in MODES
@@ -39,13 +31,6 @@ end
 @testset "get unrolled_mode" begin
     @test DEQs.get_unrolled_depth(Val(10)) == 10
     @test DEQs.get_unrolled_depth((; fixed_depth = Val(10))) == 10
-end
-
-@testset "steady-state sensitivity defaults" begin
-    cpu_prob = SteadyStateProblem((u, p, t) -> u, zeros(2))
-    gpu_prob = SteadyStateProblem((u, p, t) -> u, MockGPUVector(zeros(2)))
-    @test DEQs.default_sensealg(cpu_prob) isa SteadyStateAdjoint{0, true}
-    @test DEQs.default_sensealg(gpu_prob) isa SteadyStateAdjoint{0, false}
 end
 
 @testset "deep equilibrium solution" begin


### PR DESCRIPTION
> **Please ignore this draft until it has been reviewed by @ChrisRackauckas.**

## What changed and why

DeepEquilibriumNetworks no longer overrides SciMLSensitivity's automatic `sensealg` choice. `solve` is called with `sensealg = nothing`; a user-supplied `sensealg` in the layer constructor kwargs still wins. SciMLSensitivity is still imported so the `solve` adjoint rrules load.

For the out-of-place `SteadyStateProblem`s this package constructs, that automatic choice is `SteadyStateAdjoint(autodiff = false, autojacvec = ZygoteVJP())`. The previous override kept `autodiff = true` on CPU (constructor default) and truncated the adjoint linear solve (`maxiters = 10`, `1e-3` tols). GPUArraysCore returns to a test extra; it was only needed for the GPU `autodiff` dispatch in the removed override.

This supersedes the GPU-only autodiff flip in https://github.com/SciML/DeepEquilibriumNetworks.jl/pull/243: SciMLSensitivity already sets `autodiff = false` for GPU **and** out-of-place problems.

## Verification

```text
$ GROUP=QA julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   18     18  3m25.0s
Testing DeepEquilibriumNetworks tests passed
```

```text
$ GROUP=Core julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Utils Tests   |   13     13  51.4s
Test Summary: | Pass  Total      Time
Layers Tests  | 1538   1538  23m10.9s
Testing DeepEquilibriumNetworks tests passed
```

Runic on the changed `.jl` files and `typos` over the diff both succeeded with no findings.

Docs: `makedocs` completed doctest, template expansion, citations, and document checks. The subsequent `linkcheck` step failed on a pre-existing ColPrac GitHub URL with HTTP 429 (rate limit), not on the api.md change. Two arXiv HTTP→HTTPS 301 warnings are also pre-existing.

## Not verified locally

No CUDA GPU on this host, so the GPU test group was not run. Allowed-to-fail / downstream jobs were not run.

## Behavior change

On large states (`length(u0) > 50`) this is not a no-op: the old truncated Krylov kwargs produced a different adjoint than SciMLSensitivity's default linear solve. That is intentional; the truncated solve was a DEQ-specific cheap adjoint, not a better general choice.

🤖 Generated with Grok Build (model: grok-4.6)
Agent-Session: local session ID 01a045fe-9bed-73c2-8681-bb5d74884034