### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "Lux,NonlinearSolve,OrdinaryDiffEqTsit5,StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,43 @@
+using DeepEquilibriumNetworks, BenchmarkTools
+using Lux, Random, StableRNGs
+using NonlinearSolve, OrdinaryDiffEqTsit5
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(0)
+
+function dense_layer(args...; kwargs...)
+    init_weight(rng::AbstractRNG, dims...) = randn(rng, Float32, dims) .* 0.001f0
+    return Dense(args...; init_weight, use_bias = false, kwargs...)
+end
+
+# =============================================================================
+# DeepEquilibriumNetwork — construction, setup, forward (fixed-point solve)
+# =============================================================================
+
+model = Parallel(+, dense_layer(2 => 2), dense_layer(2 => 2))
+deq = DeepEquilibriumNetwork(model, Tsit5())
+skip_deq = SkipDeepEquilibriumNetwork(model, dense_layer(2 => 2), Tsit5())
+nlsolve_deq = DeepEquilibriumNetwork(
+    Parallel(+, dense_layer(4 => 4), dense_layer(4 => 4)),
+    NewtonRaphson()
+)
+
+ps, st = Lux.setup(rng, deq)
+ps_s, st_s = Lux.setup(rng, skip_deq)
+ps_n, st_n = Lux.setup(rng, nlsolve_deq)
+
+x = randn(rng, Float32, 2, 4)
+x_n = randn(rng, Float32, 4, 4)
+
+SUITE["deq"] = BenchmarkGroup()
+
+SUITE["deq"]["construct"] = @benchmarkable DeepEquilibriumNetwork(
+    $model, Tsit5()
+)
+SUITE["deq"]["construct_skip"] = @benchmarkable SkipDeepEquilibriumNetwork(
+    $model, dense_layer(2 => 2), Tsit5()
+)
+SUITE["deq"]["setup"] = @benchmarkable Lux.setup($rng, $deq)
+SUITE["deq"]["forward"] = @benchmarkable $deq($x, $ps, $st)
+SUITE["deq"]["forward_skip"] = @benchmarkable $skip_deq($x, $ps_s, $st_s)
+SUITE["deq"]["forward_newton"] = @benchmarkable $nlsolve_deq($x_n, $ps_n, $st_n)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~31s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~31s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 Max)
Session: local transcript /home/crackauc/.local/share/devin/cli/summaries/history_ccb52064e6514b21.md